### PR TITLE
feat:add switch nodes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@ from .comfyui_script_to_video_suite.s2v_nodes.s2v_chunker_node import PDFChunker
 from .comfyui_script_to_video_suite.s2v_nodes.s2v_storyboard_node import StoryboardGenerator
 from .comfyui_script_to_video_suite.s2v_nodes.s2v_prompt_gen_node import PromptGenerator
 from .comfyui_script_to_video_suite.s2v_nodes.s2v_executor_nodes import PromptUnpacker, IterativeExecutor
-from .comfyui_script_to_video_suite.s2v_nodes.s2v_utility_nodes import StringSwitch_S2V, ListSwitch_S2V
+from .comfyui_script_to_video_suite.s2v_nodes.s2v_utility_nodes import StringSwitch_S2V
 
 NODE_CLASS_MAPPINGS = {
     "PDFChunker_S2V": PDFChunker,
@@ -12,7 +12,6 @@ NODE_CLASS_MAPPINGS = {
     "PromptUnpacker_S2V": PromptUnpacker,
     "IterativeExecutor_S2V": IterativeExecutor,
     "StringSwitch_S2V": StringSwitch_S2V,
-    "ListSwitch_S2V": ListSwitch_S2V,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -22,7 +21,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "PromptUnpacker_S2V": "4. Prompt Unpacker (S2V)",
     "IterativeExecutor_S2V": "5. Iterative Executor (S2V)",
     "StringSwitch_S2V": "Debug String Switch (S2V)",
-    "ListSwitch_S2V": "Debug List/Chunk Switch (S2V)",
 }
 
 # --- A confirmation message that your package was loaded ---

--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,9 @@
 
-
 from .comfyui_script_to_video_suite.s2v_nodes.s2v_chunker_node import PDFChunker
 from .comfyui_script_to_video_suite.s2v_nodes.s2v_storyboard_node import StoryboardGenerator
 from .comfyui_script_to_video_suite.s2v_nodes.s2v_prompt_gen_node import PromptGenerator
 from .comfyui_script_to_video_suite.s2v_nodes.s2v_executor_nodes import PromptUnpacker, IterativeExecutor
+from .comfyui_script_to_video_suite.s2v_nodes.s2v_utility_nodes import StringSwitch_S2V, ListSwitch_S2V
 
 NODE_CLASS_MAPPINGS = {
     "PDFChunker_S2V": PDFChunker,
@@ -11,6 +11,8 @@ NODE_CLASS_MAPPINGS = {
     "PromptGenerator_S2V": PromptGenerator,
     "PromptUnpacker_S2V": PromptUnpacker,
     "IterativeExecutor_S2V": IterativeExecutor,
+    "StringSwitch_S2V": StringSwitch_S2V,
+    "ListSwitch_S2V": ListSwitch_S2V,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -19,6 +21,8 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "PromptGenerator_S2V": "3. Prompt Generator (S2V)",
     "PromptUnpacker_S2V": "4. Prompt Unpacker (S2V)",
     "IterativeExecutor_S2V": "5. Iterative Executor (S2V)",
+    "StringSwitch_S2V": "Debug String Switch (S2V)",
+    "ListSwitch_S2V": "Debug List/Chunk Switch (S2V)",
 }
 
 # --- A confirmation message that your package was loaded ---

--- a/comfyui_script_to_video_suite/s2v_nodes/s2v_utility_nodes.py
+++ b/comfyui_script_to_video_suite/s2v_nodes/s2v_utility_nodes.py
@@ -25,9 +25,10 @@ class StringSwitch_S2V:
             return (manual_input,)
         
         if generated_input is None:
-            print("⚠️ S2V Switch Warning: Workflow mode is ON, but nothing is connected to 'generated_input'. Returning empty string.")
-            return ("",)
-
+            error_message = "❌ FATAL ERROR: Switch is in Workflow Mode (use_manual=False), but nothing is connected to 'generated_input'!"
+            print(error_message)
+            raise ValueError(error_message)
+             
         print("🔄 S2V Switch: Using GENERATED input.")
         return (generated_input,)
 

--- a/comfyui_script_to_video_suite/s2v_nodes/s2v_utility_nodes.py
+++ b/comfyui_script_to_video_suite/s2v_nodes/s2v_utility_nodes.py
@@ -1,0 +1,64 @@
+class StringSwitch_S2V:
+    """
+    A logic gate that allows switching between workflow output and manual entry.
+    """
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "manual_input": ("STRING", {"multiline": True, "default": ""}),
+                "use_manual": ("BOOLEAN", {"default": False}),
+            },
+            "optional": {
+                "generated_input": ("STRING", {"forceInput": True}),
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("selected_string",)
+    FUNCTION = "switch_logic"
+    CATEGORY = "Script To Video Suite/Logic"
+
+    def switch_logic(self, manual_input, use_manual, generated_input=None):
+        if use_manual:
+            print("🔧 S2V Switch: Using MANUAL input.")
+            return (manual_input,)
+        
+        if generated_input is None:
+            print("⚠️ S2V Switch Warning: Workflow mode is ON, but nothing is connected to 'generated_input'. Returning empty string.")
+            return ("",)
+
+        print("🔄 S2V Switch: Using GENERATED input.")
+        return (generated_input,)
+
+# the class below may not function as it is intended to be, so please use the one above if required. 
+class ListSwitch_S2V:
+    """
+    A specific switch for the Chunker output.
+    - Workflow Mode: Passes the list of chunks through unchanged.
+    - Manual Mode: Takes your text and wraps it in a list (as if it were 1 chunk)
+      so the next node can process it.
+    """
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "generated_list": ("*",), 
+                "manual_text": ("STRING", {"multiline": True, "default": ""}),
+                "use_manual": ("BOOLEAN", {"default": False}),
+            }
+        }
+
+    RETURN_TYPES = ("*",)
+    RETURN_NAMES = ("selected_list",)
+    FUNCTION = "switch_logic"
+    CATEGORY = "Script To Video Suite/Logic"
+
+    def switch_logic(self, generated_list, manual_text, use_manual):
+        if use_manual:
+            print(" List Switch: Using MANUAL input. Converting text to single-item list.")
+            return ([manual_text],)
+        else:
+            print(f"🔄 List Switch: Passing through generated list data.")
+            return (generated_list,)
+            

--- a/comfyui_script_to_video_suite/s2v_nodes/s2v_utility_nodes.py
+++ b/comfyui_script_to_video_suite/s2v_nodes/s2v_utility_nodes.py
@@ -31,34 +31,4 @@ class StringSwitch_S2V:
         print("🔄 S2V Switch: Using GENERATED input.")
         return (generated_input,)
 
-# the class below may not function as it is intended to be, so please use the one above if required. 
-class ListSwitch_S2V:
-    """
-    A specific switch for the Chunker output.
-    - Workflow Mode: Passes the list of chunks through unchanged.
-    - Manual Mode: Takes your text and wraps it in a list (as if it were 1 chunk)
-      so the next node can process it.
-    """
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "generated_list": ("*",), 
-                "manual_text": ("STRING", {"multiline": True, "default": ""}),
-                "use_manual": ("BOOLEAN", {"default": False}),
-            }
-        }
-
-    RETURN_TYPES = ("*",)
-    RETURN_NAMES = ("selected_list",)
-    FUNCTION = "switch_logic"
-    CATEGORY = "Script To Video Suite/Logic"
-
-    def switch_logic(self, generated_list, manual_text, use_manual):
-        if use_manual:
-            print(" List Switch: Using MANUAL input. Converting text to single-item list.")
-            return ([manual_text],)
-        else:
-            print(f"🔄 List Switch: Passing through generated list data.")
-            return (generated_list,)
             


### PR DESCRIPTION
### Summary
- This pull request implements another custom node that will be used during **development**. The problem statement behind this pull request is: while trying to generates images and videos, the server needed to first  parse the script and provide the prompts every time. This created an overhead of time and computation that is not required during testing of nodes that are found later in the pipeline( automatic lora loader). The solution was to develop custom nodes where a finished parsed script is given manually and the pipeline continues generating as in normal case but with zero overhead of computation and time.
### Changes Made
- `__init__.py` : add the new nodes to the registery
- `s2v_utility_nodes.py`: main implementation file 

### Motivation / Context
 -   Given in the summary 
### Technical Details
-  
 
### Dependencies / Related PRs
-  No additional dependency  
### Checklist
- [x] Code follows project conventions
- [x]  All tests pass locally
- [x]  Documentation updated (README, comments, docstrings)
- [x]  PR title is descriptive
- [x]  No unnecessary commits or debug prints
