### PR TITLE
Fix lora merger node for kajia workflow

### DIFF
--- a/comfyui_script_to_video_suite/s2v_nodes/s2v_multi_lora_loader_node.py
+++ b/comfyui_script_to_video_suite/s2v_nodes/s2v_multi_lora_loader_node.py
@@ -11,8 +11,8 @@ class MultiLoraLoader_S2V:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "model": ("*",), 
-                "clip": ("*",), 
+                "model": ("WANVIDEOMODEL",), 
+                "clip": ("WANVIDEOTEXTEMBEDS",), 
                 "lora_stack": ("LORA_STACK",), 
             }
         }
@@ -28,20 +28,11 @@ class MultiLoraLoader_S2V:
 
         print(f"🔥 MultiLora: Processing stack with {len(lora_stack)} items...")
 
-        work_model = model
-        is_wrapper = False
-        
-        if hasattr(model, "model"):
-            print("⚙️ MultiLora: Detected Wrapper. Patching internal model...")
-            work_model = model.model
-            is_wrapper = True
-        
-        current_model = work_model
+        current_model = model
         current_clip = clip
 
         for lora_name, strength_model, strength_clip in lora_stack:
             resolved_path = None
-            
             resolved_path = folder_paths.get_full_path("loras", lora_name)
             
             if resolved_path is None and os.path.exists(lora_name):
@@ -56,16 +47,21 @@ class MultiLoraLoader_S2V:
             try:
                 lora_sd = comfy.utils.load_torch_file(resolved_path)
                 
-                current_model, current_clip = comfy.sd.load_lora_for_models(
-                    current_model, current_clip, lora_sd, strength_model, strength_clip
-                )
+                # --- NEW LOGIC: Try/Except/Fallback ---
+                try:
+                    # Attempt 1: Patch Model AND Clip (Standard behavior)
+                    current_model, current_clip = comfy.sd.load_lora_for_models(
+                        current_model, current_clip, lora_sd, strength_model, strength_clip
+                    )
+                except AttributeError:
+                    # Attempt 2: If CLIP is incompatible (e.g. WanVideo Embeddings Dict), 
+                    # we ignore CLIP and ONLY patch the Model.
+                    print(f"⚠️ Warning: CLIP/T5 is incompatible with standard patching. Applying LoRA to MODEL only.")
+                    current_model, _ = comfy.sd.load_lora_for_models(
+                        current_model, None, lora_sd, strength_model, 0
+                    )
             except Exception as e:
                 print(f"❌ Error merging LoRA {lora_name}: {e}")
                 continue
 
-        if is_wrapper:
-            # Update wrapper reference
-            model.model = current_model
-            return (model, current_clip)
-        else:
-            return (current_model, current_clip)
+        return (current_model, current_clip)

--- a/comfyui_script_to_video_suite/s2v_nodes/s2v_multi_lora_loader_node.py
+++ b/comfyui_script_to_video_suite/s2v_nodes/s2v_multi_lora_loader_node.py
@@ -11,29 +11,61 @@ class MultiLoraLoader_S2V:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "model": ("MODEL",),
-                "clip": ("CLIP",),
-                "lora_stack": ("LORA_STACK",),  # now required
+                "model": ("*",), 
+                "clip": ("*",), 
+                "lora_stack": ("LORA_STACK",), 
             }
         }
 
-    RETURN_TYPES = ("MODEL", "CLIP")
+    RETURN_TYPES = ("WANVIDEOMODEL", "WANVIDEOTEXTEMBEDS")
+    RETURN_NAMES = ("wan_model", "wan_t5_clip")
     FUNCTION = "load_loras"
     CATEGORY = "Script To Video Suite"
 
     def load_loras(self, model, clip, lora_stack):
-        result = (model, clip)
+        if not lora_stack:
+            return (model, clip)
 
-        # Apply loras from incoming stack
-        for lora_path, strength_model, strength_clip in lora_stack:
-            # Resolve full path in case AutoLoraLoader_S2V returned just a filename
-            if not os.path.isabs(lora_path) and os.path.sep not in lora_path:
-                resolved_path = folder_paths.get_full_path("loras", lora_path)
-            else:
-                resolved_path = lora_path
+        print(f"🔥 MultiLora: Processing stack with {len(lora_stack)} items...")
 
-            lora_sd = comfy.utils.load_torch_file(resolved_path)
-            result = comfy.sd.load_lora_for_models(result[0], result[1], lora_sd, strength_model, strength_clip)
+        work_model = model
+        is_wrapper = False
+        
+        if hasattr(model, "model"):
+            print("⚙️ MultiLora: Detected Wrapper. Patching internal model...")
+            work_model = model.model
+            is_wrapper = True
+        
+        current_model = work_model
+        current_clip = clip
 
-        return result
+        for lora_name, strength_model, strength_clip in lora_stack:
+            resolved_path = None
+            
+            resolved_path = folder_paths.get_full_path("loras", lora_name)
+            
+            if resolved_path is None and os.path.exists(lora_name):
+                resolved_path = lora_name
 
+            if resolved_path is None:
+                print(f"❌ Error: LoRA file not found: {lora_name}")
+                continue
+
+            print(f"   -> Loading: {lora_name}")
+            
+            try:
+                lora_sd = comfy.utils.load_torch_file(resolved_path)
+                
+                current_model, current_clip = comfy.sd.load_lora_for_models(
+                    current_model, current_clip, lora_sd, strength_model, strength_clip
+                )
+            except Exception as e:
+                print(f"❌ Error merging LoRA {lora_name}: {e}")
+                continue
+
+        if is_wrapper:
+            # Update wrapper reference
+            model.model = current_model
+            return (model, current_clip)
+        else:
+            return (current_model, current_clip)


### PR DESCRIPTION
This pull request updates the `s2v_multi_lora_loader_node.py` to improve compatibility with different model and clip types, and adds more robust error handling and logging when loading and applying multiple LoRA models. The changes ensure that the node works correctly with the new WANVideo model types and gracefully handles incompatible CLIP types.

**Compatibility and type updates:**
- Changed input and return types from `"MODEL"`/`"CLIP"` to `"WANVIDEOMODEL"`/`"WANVIDEOTEXTEMBEDS"` to support new model variants.
- Updated return variable names to `wan_model` and `wan_t5_clip` for clarity so they can be integrated with the .

**Robustness and error handling:**
- Improved LoRA file resolution logic and added detailed print statements for debugging, including error messages when LoRA files are not found or cannot be merged.
- Added try/except logic to handle cases where the CLIP/T5 embedding is incompatible with LoRA patching, applying the LoRA only to the model in such cases and logging a warning.