### PR TITLE
refactor(Multi-Lora-Loader-Node): convert MultiLoraLoader to configuration-based architecture

### DIFF
--- a/comfyui_script_to_video_suite/s2v_nodes/s2v_multi_lora_loader_node.py
+++ b/comfyui_script_to_video_suite/s2v_nodes/s2v_multi_lora_loader_node.py
@@ -1,67 +1,59 @@
 import folder_paths
-import comfy.utils
-import comfy.sd
 import os
 
 class MultiLoraLoader_S2V:
-    def __init__(self):
-        pass
-    
+
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "model": ("WANVIDEOMODEL",), 
-                "clip": ("WANVIDEOTEXTEMBEDS",), 
                 "lora_stack": ("LORA_STACK",), 
             }
         }
 
-    RETURN_TYPES = ("WANVIDEOMODEL", "WANVIDEOTEXTEMBEDS")
-    RETURN_NAMES = ("wan_model", "wan_t5_clip")
-    FUNCTION = "load_loras"
+    RETURN_TYPES = ("WANVIDLORA",)
+    RETURN_NAMES = ("loras_list",)
+    FUNCTION = "prepare_loras"
     CATEGORY = "Script To Video Suite"
 
-    def load_loras(self, model, clip, lora_stack):
+    def prepare_loras(self, lora_stack):
         if not lora_stack:
-            return (model, clip)
+            print("⚠️ Empty lora_stack: No LoRA configurations provided.")
+            return (None,)
 
         print(f"🔥 MultiLora: Processing stack with {len(lora_stack)} items...")
 
-        current_model = model
-        current_clip = clip
+        loras_list = []
 
         for lora_name, strength_model, strength_clip in lora_stack:
-            resolved_path = None
+            #  LoRA file path
             resolved_path = folder_paths.get_full_path("loras", lora_name)
             
+            # Fallback: check if lora_name is already an absolute path
             if resolved_path is None and os.path.exists(lora_name):
                 resolved_path = lora_name
 
             if resolved_path is None:
-                print(f"❌ Error: LoRA file not found: {lora_name}")
+                print(f"❌ LoRA file not found: {lora_name}")
                 continue
 
-            print(f"   -> Loading: {lora_name}")
+            # Build configuration dictionary 
+            lora_config = {
+                "path": resolved_path,
+                "strength": strength_model,  
+                "name": os.path.splitext(os.path.basename(lora_name))[0],
+                "merge_loras": True,
+                "low_mem_load": False,
+                "blocks": {},
+                "layer_filter": ""
+            }
             
-            try:
-                lora_sd = comfy.utils.load_torch_file(resolved_path)
-                
-                # --- NEW LOGIC: Try/Except/Fallback ---
-                try:
-                    # Attempt 1: Patch Model AND Clip (Standard behavior)
-                    current_model, current_clip = comfy.sd.load_lora_for_models(
-                        current_model, current_clip, lora_sd, strength_model, strength_clip
-                    )
-                except AttributeError:
-                    # Attempt 2: If CLIP is incompatible (e.g. WanVideo Embeddings Dict), 
-                    # we ignore CLIP and ONLY patch the Model.
-                    print(f"⚠️ Warning: CLIP/T5 is incompatible with standard patching. Applying LoRA to MODEL only.")
-                    current_model, _ = comfy.sd.load_lora_for_models(
-                        current_model, None, lora_sd, strength_model, 0
-                    )
-            except Exception as e:
-                print(f"❌ Error merging LoRA {lora_name}: {e}")
-                continue
+            loras_list.append(lora_config)
+            print(f"   ✅ Added: {lora_name} (Strength: {strength_model})")
 
-        return (current_model, current_clip)
+        if not loras_list:
+            print("⚠️ No valid LoRAs found in stack.")
+            return (None,)
+
+        print(f"✅ Prepared {len(loras_list)} LoRA configuration(s)")
+        return (loras_list,)

--- a/comfyui_script_to_video_suite/s2v_nodes/s2v_multi_lora_loader_node.py
+++ b/comfyui_script_to_video_suite/s2v_nodes/s2v_multi_lora_loader_node.py
@@ -1,10 +1,29 @@
+"""
+Multi-LoRA loader node for the Script-To-Video suite.
+Resolves LoRA names to filesystem paths.
+Builds configuration dictionaries for each resolved LoRA.
+Returns a list of LoRA configs or (None,) when none found.
+"""
+
 import folder_paths
 import os
 
 class MultiLoraLoader_S2V:
+    """
+    Prepares LoRA configuration dictionaries for downstream use.
+    Resolves provided LoRA names to paths and validates files.
+    Sets default merge and load metadata for each LoRA.
+    Returns a list used by later loader/merger nodes.
+    """
 
     @classmethod
     def INPUT_TYPES(cls):
+        """
+        Return the node's input type specification (required inputs).
+        Declares `lora_stack` as the required `LORA_STACK` input.
+        Expects tuples (name, strength_model, strength_clip).
+        Only name and strength_model are used by this loader.
+        """
         return {
             "required": {
                 "lora_stack": ("LORA_STACK",), 

--- a/comfyui_script_to_video_suite/s2v_nodes/s2v_multi_lora_loader_node.py
+++ b/comfyui_script_to_video_suite/s2v_nodes/s2v_multi_lora_loader_node.py
@@ -44,13 +44,13 @@ class MultiLoraLoader_S2V:
 
         loras_list = []
 
-        for lora_name, strength_model, strength_clip in lora_stack:
-            #  LoRA file path
+        for lora_name, strength_model, _ in lora_stack:
+            #  Resolve LoRA file path
             resolved_path = folder_paths.get_full_path("loras", lora_name)
             
             # Fallback: check if lora_name is already an absolute path
             if resolved_path is None and os.path.exists(lora_name):
-                resolved_path = lora_name
+                resolved_path = os.path.realpath(lora_name)
 
             if resolved_path is None:
                 print(f"❌ LoRA file not found: {lora_name}")


### PR DESCRIPTION
## Overview
Refactor ```MultiLoraLoader_S2V``` to align with the WanVideoWrapper pattern. The node now generates LoRA
configuration dictionaries instead of directly patching model weights.

---

### Changes:
- Remove model and clip inputs, accept only lora_stack
- Change return type from (```WANVIDEOMODEL```, ```WANVIDEOTEXTEMBEDS```) to (```WANVIDLORA,```)
- Replace ```load_loras()``` with ```prepare_loras()``` to reflect new behavior
- Remove ```comfy.utils``` and ```comfy.sd``` dependencies
- Generate configuration dictionaries with ```path, strength, name, and metadata```
- Handle edge cases: empty stack, missing LoRA files

------
This change enables better composability by decoupling LoRA configuration
from model loading, allowing downstream nodes to handle the actual weight
patching based on the provided configurations.
